### PR TITLE
minor chart improvements; fix notifications and wrong label name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can also download the release apk from [releases](https://github.com/z3r0c00
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
-Please make sure to update tests as appropriat
+Please make sure to update tests as appropriate
 
 ## License
 [GPL-3.0](https://github.com/z3r0c00l-2k/AquaDroid/blob/master/LICENSE)

--- a/app/src/main/java/io/github/z3r0c00l_2k/aquadroid/InitUserInfoActivity.kt
+++ b/app/src/main/java/io/github/z3r0c00l_2k/aquadroid/InitUserInfoActivity.kt
@@ -29,6 +29,9 @@ class InitUserInfoActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val is24h = android.text.format.DateFormat.is24HourFormat(this.applicationContext)
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
         }
@@ -56,7 +59,7 @@ class InitUserInfoActivity : AppCompatActivity() {
                     etWakeUpTime.editText!!.setText(
                         String.format("%02d:%02d", selectedHour, selectedMinute)
                     )
-                }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), false
+                }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), is24h
             )
             mTimePicker.setTitle("Select Wakeup Time")
             mTimePicker.show()
@@ -80,7 +83,7 @@ class InitUserInfoActivity : AppCompatActivity() {
                     etSleepTime.editText!!.setText(
                         String.format("%02d:%02d", selectedHour, selectedMinute)
                     )
-                }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), false
+                }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), is24h
             )
             mTimePicker.setTitle("Select Sleeping Time")
             mTimePicker.show()

--- a/app/src/main/java/io/github/z3r0c00l_2k/aquadroid/MainActivity.kt
+++ b/app/src/main/java/io/github/z3r0c00l_2k/aquadroid/MainActivity.kt
@@ -1,5 +1,6 @@
 package io.github.z3r0c00l_2k.aquadroid
 
+import android.app.NotificationManager
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
@@ -119,6 +120,11 @@ class MainActivity : AppCompatActivity() {
                 op200ml.background = getDrawable(outValue.resourceId)
                 op250ml.background = getDrawable(outValue.resourceId)
                 opCustom.background = getDrawable(outValue.resourceId)
+
+                // remove pending notifications
+                val mNotificationManager : NotificationManager =
+                    getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+                mNotificationManager.cancelAll()
             } else {
                 YoYo.with(Techniques.Shake)
                     .duration(700)

--- a/app/src/main/java/io/github/z3r0c00l_2k/aquadroid/StatsActivity.kt
+++ b/app/src/main/java/io/github/z3r0c00l_2k/aquadroid/StatsActivity.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.github.mikephil.charting.animation.Easing
+import com.github.mikephil.charting.components.LimitLine
 import com.github.mikephil.charting.components.XAxis
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.data.LineData
@@ -16,6 +17,7 @@ import io.github.z3r0c00l_2k.aquadroid.helpers.SqliteHelper
 import io.github.z3r0c00l_2k.aquadroid.utils.AppUtils
 import io.github.z3r0c00l_2k.aquadroid.utils.ChartXValueFormatter
 import kotlinx.android.synthetic.main.activity_stats.*
+import kotlin.math.max
 
 
 class StatsActivity : AppCompatActivity() {
@@ -77,11 +79,20 @@ class StatsActivity : AppCompatActivity() {
             chart.xAxis.setDrawAxisLine(false)
             chart.setDrawMarkers(false)
             chart.xAxis.labelCount = 5
-            val rightAxix = chart.axisRight
-            rightAxix.setDrawGridLines(false)
-            rightAxix.setDrawZeroLine(false)
-            rightAxix.setDrawAxisLine(false)
-            rightAxix.setDrawLabels(false)
+
+            val leftAxis = chart.axisLeft
+            leftAxis.axisMinimum = 0f // always start at zero
+            val maxObject: Entry = entries.maxBy { it.y }!! // entries is not empty here
+            leftAxis.axisMaximum = max(a = maxObject.y, b = 100f) + 15f // 15% margin on top
+            val targetLine = LimitLine(100f, "")
+            targetLine.enableDashedLine(5f, 5f, 0f)
+            leftAxis.addLimitLine(targetLine)
+
+            val rightAxis = chart.axisRight
+            rightAxis.setDrawGridLines(false)
+            rightAxis.setDrawZeroLine(false)
+            rightAxis.setDrawAxisLine(false)
+            rightAxis.setDrawLabels(false)
 
             val dataSet = LineDataSet(entries, "Label")
             dataSet.setDrawCircles(false)

--- a/app/src/main/java/io/github/z3r0c00l_2k/aquadroid/fragments/BottomSheetFragment.kt
+++ b/app/src/main/java/io/github/z3r0c00l_2k/aquadroid/fragments/BottomSheetFragment.kt
@@ -21,6 +21,7 @@ import io.github.z3r0c00l_2k.aquadroid.helpers.SqliteHelper
 import io.github.z3r0c00l_2k.aquadroid.utils.AppUtils
 import kotlinx.android.synthetic.main.bottom_sheet_fragment.*
 import java.math.RoundingMode
+import java.text.DateFormat
 import java.text.DecimalFormat
 import java.util.*
 
@@ -49,6 +50,8 @@ class BottomSheetFragment(val mCtx: Context) : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val is24h = android.text.format.DateFormat.is24HourFormat(mCtx)
 
         sharedPref = mCtx.getSharedPreferences(AppUtils.USERS_SHARED_PREF, AppUtils.PRIVATE_MODE)
 
@@ -142,7 +145,7 @@ class BottomSheetFragment(val mCtx: Context) : BottomSheetDialogFragment() {
                     etWakeUpTime.editText!!.setText(
                         String.format("%02d:%02d", selectedHour, selectedMinute)
                     )
-                }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), false
+                }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), is24h
             )
             mTimePicker.setTitle("Select Wakeup Time")
             mTimePicker.show()
@@ -167,7 +170,7 @@ class BottomSheetFragment(val mCtx: Context) : BottomSheetDialogFragment() {
                     etSleepTime.editText!!.setText(
                         String.format("%02d:%02d", selectedHour, selectedMinute)
                     )
-                }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), false
+                }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), is24h
             )
             mTimePicker.setTitle("Select Sleeping Time")
             mTimePicker.show()

--- a/app/src/main/res/layout/bottom_sheet_fragment.xml
+++ b/app/src/main/res/layout/bottom_sheet_fragment.xml
@@ -126,7 +126,7 @@
                 android:background="@null"
                 android:clickable="true"
                 android:focusable="false"
-                android:hint="@string/wakeup_hint"
+                android:hint="@string/sleeping_hint"
                 android:inputType="numberSigned"
                 android:paddingStart="10dp"
                 android:paddingBottom="10dp" />


### PR DESCRIPTION
Hi, I would like to merge minor changes in the Summary chart and how notifications behave:
* always start at zero. This way it is easier to see whether a drop in intake is ok or not. Consider you have 150% each day and then drop to 100% - if it doesn't start at zero, it looks like the 100% are not enough intake
* ensure that 100% is always visible, so if you have 50% each day you can better see that it is not enough
* draw a line at 100%
* fix minor typo
* use system default 12h or 24h setting
* notify only when behind target intake, grows linearly over the period of the day
* cancel notification on intake
* fix wrong label name in settings

nice project btw! :)

screenshot:
![Screenshot_1591354120](https://user-images.githubusercontent.com/40864125/83869582-153e6900-a72d-11ea-805b-90019cc2ab55.png)
